### PR TITLE
Fix mobile header button width

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -43,10 +43,9 @@ h2 {
   object-fit: cover;
   width: 250px;
   height: 250px;
-  border-radius: 50%;
+  border-radius: 20%;
   display: block;
-  margin-left: auto;
-  margin-top: 45px;
+  margin: 45px auto 0 auto;
 }
 
 @media screen and (max-width: 700px) {
@@ -54,9 +53,9 @@ h2 {
     object-fit: cover;
     width: 100px;
     height: 100px;
-    border-radius: 50%;
+    border-radius: 20%;
     display: block;
-    margin-top: 120px;
+    margin: 120px auto 0 auto;
   }
   h1 {
     font-size: 16px;
@@ -64,6 +63,7 @@ h2 {
   #header {
     flex-direction: column;
     height: auto;
+    align-items: center;
   }
   #header-links {
     flex-direction: row;
@@ -71,6 +71,7 @@ h2 {
     justify-content: center;
     gap: 12px;
     padding: 20px 0;
+    width: 100%;
   }
   .project-container {
     margin-left: auto;


### PR DESCRIPTION
## Summary
- keep GitHub and LinkedIn buttons full width on small screens
- prior commit: soften headshot border into a rounded square and center it on narrow screens

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684240834ba0832e9622fd7d93ba0636